### PR TITLE
Test iterable elements data

### DIFF
--- a/packages/dom-element-descriptors/src/__tests__/end-to-end.ts
+++ b/packages/dom-element-descriptors/src/__tests__/end-to-end.ts
@@ -17,8 +17,8 @@ class QueryData {
     return document.querySelector(this.selector);
   }
 
-  get elements(): Element[] {
-    return Array.from(document.querySelectorAll(this.selector));
+  get elements(): Iterable<Element> {
+    return document.querySelectorAll(this.selector);
   }
 }
 

--- a/packages/dom-element-descriptors/tsconfig.json
+++ b/packages/dom-element-descriptors/tsconfig.json
@@ -18,7 +18,8 @@
     "experimentalDecorators": true,
     "lib": [
       "ES2017",
-      "DOM"
+      "DOM",
+      "DOM.Iterable"
     ],
   },
   "include": [


### PR DESCRIPTION
Make our test descriptor data return the most generic type allowed for `elements`, `Iterable<Element>` rather than a more specific type, `Element[]`